### PR TITLE
Use ex syntax highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,43 +15,57 @@ Instead of `|>` we can use `>>>` to pipe `{:ok, val} | {:error, error}` returnin
 
 As written in `test/rop_test.exs`:
 
-    use Rop
+```ex
+use Rop
+```
 
 Using Rop defines `>>>` operator.
 
-    test "Count to 3" do
-      assert (ok(0) >>> ok >>> ok) == {:ok, 3}
-    end
+```ex
+test "Count to 3" do
+  assert (ok(0) >>> ok >>> ok) == {:ok, 3}
+end
+```
 
 We increase `0` three times to end up with `{:ok, 3}`.
 
-    test "Error" do
-      assert (ok(0) >>> error) == {:error, "Error at 1"}
-    end
+```ex
+test "Error" do
+  assert (ok(0) >>> error) == {:error, "Error at 1"}
+end
+```
 
 Error function always return error.
 
-    test "Error propagation" do
-      assert (ok(0) >>> error >>> ok) == {:error, "Error at 1"}
-    end
+```ex
+test "Error propagation" do
+  assert (ok(0) >>> error >>> ok) == {:error, "Error at 1"}
+end
+```
 
 Error was propagated and second `ok` was not called.
 
-    test "First error is returned" do
-      assert (ok(0) >>> error >>> error) == {:error, "Error at 1"}
-    end
+```ex
+test "First error is returned" do
+  assert (ok(0) >>> error >>> error) == {:error, "Error at 1"}
+end
+```
 
 Only first error is returned, since next `error` is never called.
 
-    defp ok(cnt) do
-      {:ok, cnt + 1}
-    end
+```ex
+defp ok(cnt) do
+  {:ok, cnt + 1}
+end
 
+```
 `ok/1` function takes value and increases it, returning standard `{:ok, val}` response.
 
-    defp error(cnt) do
-      {:error, "Error at #{cnt}"}
-    end
+```ex
+defp error(cnt) do
+  {:error, "Error at #{cnt}"}
+end
+```
 
 `error/1` function takes value and returns standard `{:error, string}` that identifies where error was called.
 


### PR DESCRIPTION
Check the rich diff: https://github.com/remiq/railway-oriented-programming-elixir/pull/1/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8